### PR TITLE
Fix tests for .bike and .io.

### DIFF
--- a/parse-raw-data.js
+++ b/parse-raw-data.js
@@ -45,7 +45,7 @@ var usRegex = {
 	'registrar': 'Registrar: *(.+)',
 	'status': 'Domain Status: *(.+)',
 	'creationDate': 'Creation Date: *(.+)',
-	'expirationDate': 'Registry Expiry Date: *(.+)',
+	'expirationDate': '(?:Registry Expiry|Registrar Registration Expiration) Date: *(.+)',
 	'updatedDate': 'Updated Date: *(.+)',
 	'notFound': '^No Data Found',
 	'dateFormat': 'YYYY-MM-DDThh:mm:ssZ'
@@ -234,12 +234,12 @@ var kgRegex = {
 var idRegex = {
 	'domainName': 'Domain Name:([^\\s]+)',
 	'creationDate': 'Created On:(.+)',
-	'expirationDate': 'Expiration Date(.+)',
-	'updatedDate': 'Last Updated On(.+)',
+	'expirationDate': 'Expiration Date: (.+)',
+	'updatedDate': 'Last Updated On: (.+)',
 	'registrar': 'Sponsoring Registrar Organization:(.+)',
 	'status': 'Status:(.+)',
 	'notFound': 'DOMAIN NOT FOUND',
-	'dateFormat': 'DD-MMM-YYYY HH:mm:ss UTC'
+	'dateFormat': 'YYYY-MM-DD HH:mm:ss'
 };
 
 var skRegex = {

--- a/test/test.js
+++ b/test/test.js
@@ -331,7 +331,7 @@ describe('#whoisParser integration tests', function() {
     });
 
     it('known generic tld domain (.bike) should not be available and have data', async function () {
-        await testNotAvailable('red', '.bike', {excludedFields: ['status']});
+        await testNotAvailable('nic', '.bike', {excludedFields: ['status']});
     });
     it('random generic tld domain (.bike) should be available', async function() {
         await testAvailable('.bike');
@@ -343,7 +343,7 @@ describe('#whoisParser integration tests', function() {
         await testAvailable('.asia');
     });
     it('known generic tld domain (.io) should not be available and have data', async function () {
-        await testNotAvailable('facebook', '.io', {excludedFields: ['status']} );
+        await testNotAvailable('google', '.io', {excludedFields: ['status']} );
     });
     it('random generic tld domain (.io) should be available', async function() {
         await testAvailable('.io');


### PR DESCRIPTION
These domains return incorrect `Registrar WHOIS Server` value.
whois-raw follows this link, and get `NOT FOUND`.

For `.io` domain, it may be special reason to choose `facebook` rather than `google`.  So I'm not sure using `google.io` is good or not.

For `.id` domain, return format changed.