### PR TITLE
Support more \.(..)\.jp (non general-use) domain whois format.

### DIFF
--- a/parse-raw-data.js
+++ b/parse-raw-data.js
@@ -102,11 +102,11 @@ var fiRegex = {
 };
 
 var jpRegex = {
-	'domainName': '\\[Domain Name\\]\\s*([^\\s]+)',
-	'creationDate': '\\[Created on\\]\\s*(.+)',
-	'updatedDate': '\\[Last Updated\\]\\s?(.+)',
-	'expirationDate': '\\[Expires on\\]\\s?(.+)',
-	'status': '\\[Status\\]\\s*(.+)',
+	'domainName': '(?:a\\. )\\[Domain Name\\]\\s*([^\\s]+)',
+	'creationDate': '\\[(Created on|Registered Date)\\]\\s*(.+)',
+	'updatedDate': '\\[Last Updated?\\]\\s?(.+)',
+	'expirationDate': '(?:\\[Expires on\\]|\\[State\\]\\s+Connected)\\s*\\(?(.+)\\)?',
+	'status': '\\[Stat(?:us|e)\\]\\s*(.+)',
 	'notFound': 'No match!!',
 	'dateFormat': 'YYYY/MM/DD'
 };

--- a/test/test.js
+++ b/test/test.js
@@ -179,6 +179,9 @@ describe('#whoisParser integration tests', function() {
     it('known .jp should not be available and have data', async function () {
       await testNotAvailable('google', '.jp', {excludedFields: ['registrar']});
     });
+    it('known .ad.jp should not be available and have data', async function () {
+      await testNotAvailable('nic.ad', '.jp', {excludedFields: ['registrar']});
+    });
     it('random .jp domain should be available', async function() {
       await testAvailable('.jp');
     });


### PR DESCRIPTION
`.jp` domain whois response has two format.  One is for general-use .jp domain (which already supported in `whois-parsed`), the other has different response format. 

This patch modify `jpRegex` to support both format (and add test).

Example 1 (general-use .jp domains)
```
$ whois google.jp
[ JPRS database provides information on network administration. Its use is    ]
[ restricted to network administration purposes. For further information,     ]
[ use 'whois -h whois.jprs.jp help'. To suppress Japanese output, add'/e'     ]
[ at the end of command, e.g. 'whois -h whois.jprs.jp xxx/e'.                 ]

Domain Information:
[Domain Name]                   GOOGLE.JP

[Registrant]                    Google LLC

[Name Server]                   ns1.google.com
[Name Server]                   ns2.google.com
[Name Server]                   ns3.google.com
[Name Server]                   ns4.google.com
[Signing Key]

[Created on]                    2005/05/30
[Expires on]                    2021/05/31
[Status]                        Active
[Last Updated]                  2020/08/06 13:20:20 (JST)

Contact Information:
[Name]                          Google LLC
[Email]                         dns-admin@google.com
[Web Page]
[Postal code]                   94043
[Postal Address]                Mountain View
                                1600 Amphitheatre Parkway
                                CA
[Phone]                         16502530000
[Fax]                           16502530001
```

Example 2 (non general-use domains)
```
$ [ JPRS database provides information on network administration. Its use is    ]
[ restricted to network administration purposes. For further information,     ]
[ use 'whois -h whois.jprs.jp help'. To suppress Japanese output, add'/e'     ]
[ at the end of command, e.g. 'whois -h whois.jprs.jp xxx/e'.                 ]

Domain Information:
a. [Domain Name]                GOOGLE.CO.JP
g. [Organization]               Google Japan G.K.
l. [Organization Type]          GK
m. [Administrative Contact]     YN47525JP
n. [Technical Contact]          SH36113JP
p. [Name Server]                ns1.google.com
p. [Name Server]                ns2.google.com
p. [Name Server]                ns3.google.com
p. [Name Server]                ns4.google.com
s. [Signing Key]
[State]                         Connected (2022/03/31)
[Registered Date]               2001/03/22
[Connected Date]                2001/03/22
[Last Update]                   2021/04/01 01:05:22 (JST)
```